### PR TITLE
Update VH levels

### DIFF
--- a/src/components/VaultHunter/selectors.js
+++ b/src/components/VaultHunter/selectors.js
@@ -1,3 +1,3 @@
 export function getLevel (state) {
-  return state.invested.reduce((total, current) => total + current, 3);
+  return state.invested.reduce((total, current) => total + current, 2);
 };


### PR DESCRIPTION
GuardianCon showed skill trees with points only possible starting from lvl 2, i.e. lvl 27 Moze with 25 skill points invested. You can check for yourself from a few seconds after: https://youtu.be/2G8hPDIgvkU?t=40. Thanks for the awesome website!