### PR TITLE
Update Siren skills.js

### DIFF
--- a/src/pages/Siren/skills.js
+++ b/src/pages/Siren/skills.js
@@ -239,7 +239,7 @@ const skills = {
       "Personal Space": {
         ranks: 3,
         text: "Amara's weapon shots deal Bonus Damage based on the distance to her target. The closer the target, the greater the bonus.",
-        effect: (rank, level) => `Bonus Damage: Up to +${percent(rank, 12)}% of damage dealt`,
+        effect: (rank, level) => `Bonus Damage: Up to +${percent(rank, 18)}% of damage dealt`,
       },
       "Clarity": {
         ranks: 5,


### PR DESCRIPTION
Confirmed that Personal Space is in fact still bugged, the skill provides up to 18% extra damage per skill point and not 12% as the game claims.